### PR TITLE
Fix call to getRouter()

### DIFF
--- a/lib/lucene.php
+++ b/lib/lucene.php
@@ -286,7 +286,7 @@ class Lucene extends \OC_Search_Provider {
 				$url = Util::linkTo('files', 'index.php') . '?dir='.$hit->path;
 				break;
 			default:
-				$url = \OC::getRouter()->generate('download', array('file'=>$hit->path));
+				$url = \OC::$server->getRouter()->generate('download', array('file'=>$hit->path));
 		}
 		
 		return new \OC_Search_Result(


### PR DESCRIPTION
Without this the PHP error log gets filled with:

```
[Tue Apr 15 20:16:54 2014] [error] [client 192.168.122.29] PHP Fatal error:  Call to undefined method OC::getRouter() in /var/www/core/apps-external/search_lucene/lib/lucene.php on line 289
```

@butonic 
