### PR TITLE
Fix url links to lucene result page with OC 9.1

### DIFF
--- a/search/luceneresult.php
+++ b/search/luceneresult.php
@@ -40,10 +40,11 @@ class LuceneResult extends File {
 		$this->name = basename($this->path);
 		$this->size = (int)$hit->size;
 		$this->score = $hit->score;
-		$this->link = \OCP\Util::linkTo(
-			'files',
-			'index.php',
-			array('dir' => dirname($this->path), 'scrollto' => $this->name)
+		
+		$myfile='webdav'.dirname($this->path).'/'.$this->name;
+		$this->link = \OCP\Util::linkToAbsolute(
+			'remote.php',
+			$myfile
 		);
 		$this->permissions = $this->getPermissions($this->path);
 		$this->modified = (int)$hit->mtime;


### PR DESCRIPTION
The issue is that lucene generates this type of url:

http://domain.com/files/index.php?dir=%2FDocuments&file=Example.odt

and OC 9.1 wants this:

http://domain.com/remote.php/webdav/Documents/Example.odt
