### PR TITLE
Corrected file links so search results are usable

### DIFF
--- a/search/luceneresult.php
+++ b/search/luceneresult.php
@@ -41,8 +41,8 @@ class LuceneResult extends File {
 		$this->size = (int)$hit->size;
 		$this->score = $hit->score;
 		$this->link = \OCP\Util::linkTo(
+			'apps',
 			'files',
-			'index.php',
 			array('dir' => dirname($this->path), 'scrollto' => $this->name)
 		);
 		$this->permissions = $this->getPermissions($this->path);


### PR DESCRIPTION
As mentioned in #118, the search results are currently unusable in the 10.0.4 version of ownCloud. Using the fix described in #118, I've corrected the bug. I've tested this on my own instance and it works great.

Thanks for all of the awesome work on this, it's actually pretty useful!